### PR TITLE
TESTENG-1562: Call DocFX twice because DocFx has a caching issue for …

### DIFF
--- a/.github/workflows/ReleaseBranch.yaml
+++ b/.github/workflows/ReleaseBranch.yaml
@@ -277,6 +277,9 @@ jobs:
       run: |
         Invoke-WebRequest https://github.com/dotnet/docfx/releases/download/v2.58.4/docfx.zip -OutFile docfx.zip
         Expand-Archive -Path .\docfx.zip -DestinationPath DocFx
+        
+        # DocFx needs to be called two times because of a caching issue with external crefs. 
+        DocFx/docfx.exe source/Relativity.Testing.Framework.Api.Documentation/docfx.json
         DocFx/docfx.exe source/Relativity.Testing.Framework.Api.Documentation/docfx.json
 
     - name: Publish

--- a/.github/workflows/ReleaseBranch.yaml
+++ b/.github/workflows/ReleaseBranch.yaml
@@ -277,8 +277,9 @@ jobs:
       run: |
         Invoke-WebRequest https://github.com/dotnet/docfx/releases/download/v2.58.4/docfx.zip -OutFile docfx.zip
         Expand-Archive -Path .\docfx.zip -DestinationPath DocFx
-        
-        # DocFx needs to be called two times because of a caching issue with external crefs. 
+
+        # DocFx needs to be called two times when external repository crefs are included in the xml documentation because crefs aren't loaded properly on first run.
+        # GitHub Issue: https://github.com/dotnet/docfx/issues/7636 
         DocFx/docfx.exe source/Relativity.Testing.Framework.Api.Documentation/docfx.json
         DocFx/docfx.exe source/Relativity.Testing.Framework.Api.Documentation/docfx.json
 


### PR DESCRIPTION
…external code references

Complete the following tasks before merging in your PR:
- [x] If this is a user facing change, update [version.txt](https://github.com/relativitydev/relativity.testing.framework.api/blob/master/version.txt) and [CHANGELOG.md](https://github.com/relativitydev/relativity.testing.framework.api/blob/master/CHANGELOG.md)