### PR TITLE
[TESTENG-1579] Adding GetAccessStatus strategy for IFolderService.

### DIFF
--- a/source/Relativity.Testing.Framework.Api.FunctionalTests/Strategies/Folder/FolderGetAccessStatusStrategyFixture.cs
+++ b/source/Relativity.Testing.Framework.Api.FunctionalTests/Strategies/Folder/FolderGetAccessStatusStrategyFixture.cs
@@ -1,0 +1,49 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using Relativity.Testing.Framework.Api.Strategies;
+using Relativity.Testing.Framework.Models;
+
+namespace Relativity.Testing.Framework.Api.FunctionalTests.Strategies
+{
+	[TestOf(typeof(IFolderGetAccessStatusStrategy))]
+	internal class FolderGetAccessStatusStrategyFixture : ApiServiceTestFixture<IFolderGetAccessStatusStrategy>
+	{
+		private IFolderGetAccessStatusStrategy _sut;
+
+		[SetUp]
+		public void SetUp()
+		{
+			_sut = Facade.Resolve<IFolderGetAccessStatusStrategy>();
+		}
+
+		[Test]
+		public void Get_Missing_ReturnsStatusWithExistsSetToFalse()
+		{
+			int id = int.MaxValue;
+
+			FolderAccessStatus status = _sut.Get(DefaultWorkspace.ArtifactID, id);
+
+			status.Should().NotBeNull();
+			status.Exists.Should().BeFalse();
+		}
+
+		[Test]
+		public void Get_Existing_ReturnsStatusWithExistsSetToTrue()
+		{
+			int id = 0;
+			Arrange(() =>
+			{
+				var toCreate = new Folder
+				{
+					Name = Randomizer.GetString("AT_")
+				};
+				id = Facade.Resolve<IFolderCreateStrategy>().Create(DefaultWorkspace.ArtifactID, toCreate).ArtifactID;
+			});
+
+			FolderAccessStatus status = _sut.Get(DefaultWorkspace.ArtifactID, id);
+
+			status.Should().NotBeNull();
+			status.Exists.Should().BeTrue();
+		}
+	}
+}

--- a/source/Relativity.Testing.Framework.Api.Tests/Strategies/Folder/FolderGetAccessStatusStrategyFixture.cs
+++ b/source/Relativity.Testing.Framework.Api.Tests/Strategies/Folder/FolderGetAccessStatusStrategyFixture.cs
@@ -1,0 +1,86 @@
+﻿using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using Relativity.Testing.Framework.Api.Services;
+using Relativity.Testing.Framework.Api.Strategies;
+using Relativity.Testing.Framework.Api.Validators;
+using Relativity.Testing.Framework.Models;
+
+namespace Relativity.Testing.Framework.Api.Tests.Strategies
+{
+	[TestFixture]
+	[TestOf(typeof(IFolderGetAccessStatusStrategy))]
+	internal class FolderGetAccessStatusStrategyFixture
+	{
+		private const int _VALID_WORKSPACE_ARTIFACT_ID = 1;
+		private const int _VALID_FOLDER_ARTIFACT_ID = 2;
+
+		private const string _GET_URL = "Relativity.Services.Folder.IFolderModule/Folder%20Manager/DeleteUnusedFoldersAsync";
+
+		private FolderAccessStatus _expectedAccessStatus;
+
+		private Mock<IRestService> _mockRestService;
+		private Mock<IWorkspaceIdValidator> _mockWorkspaceIdValidator;
+		private Mock<IArtifactIdValidator> _mockArtifactIdValidator;
+		private IFolderGetAccessStatusStrategy _sut;
+
+		[SetUp]
+		public void SetUp()
+		{
+			_mockRestService = new Mock<IRestService>();
+			var expectedAccessStatusDto = new FolderAccessStatusDto
+			{
+				CanView = true,
+				Exists = true
+			};
+			_expectedAccessStatus = new FolderAccessStatus
+			{
+				CanView = expectedAccessStatusDto.CanView,
+				Exists = expectedAccessStatusDto.Exists
+			};
+
+			_mockRestService.Setup(restService => restService.Post<FolderAccessStatusDto>(_GET_URL, It.IsAny<object>(), 2, null))
+				.Returns(expectedAccessStatusDto);
+			_mockWorkspaceIdValidator = new Mock<IWorkspaceIdValidator>();
+			_mockArtifactIdValidator = new Mock<IArtifactIdValidator>();
+
+			_sut = new FolderGetAccessStatusStrategy(
+				_mockRestService.Object,
+				_mockWorkspaceIdValidator.Object,
+				_mockArtifactIdValidator.Object);
+		}
+
+		[Test]
+		public void Get_WithAnyParameters_CallsWorkspaceIdValidator()
+		{
+			_sut.Get(_VALID_WORKSPACE_ARTIFACT_ID, _VALID_FOLDER_ARTIFACT_ID);
+
+			_mockWorkspaceIdValidator.Verify(validator => validator.Validate(_VALID_WORKSPACE_ARTIFACT_ID), Times.Once);
+		}
+
+		[Test]
+		public void Get_WithAnyParameters_CallsArtifactIdValidator()
+		{
+			_sut.Get(_VALID_WORKSPACE_ARTIFACT_ID, _VALID_FOLDER_ARTIFACT_ID);
+
+			_mockArtifactIdValidator.Verify(validator => validator.Validate(_VALID_FOLDER_ARTIFACT_ID, "Folder"), Times.Once);
+		}
+
+		[Test]
+		public void Get_WithValidParameters_CallsRestService()
+		{
+			_sut.Get(_VALID_WORKSPACE_ARTIFACT_ID, _VALID_FOLDER_ARTIFACT_ID);
+
+			_mockRestService.Verify(restService => restService.Post<QueryResult<Artifact>>(_GET_URL, It.IsAny<object>(), 2, null), Times.Once);
+		}
+
+		[Test]
+		public void Delete_WithValidWorkspaceArtifactID_ReturnsExpectedResponse()
+		{
+			FolderAccessStatus response = _sut.Get(_VALID_WORKSPACE_ARTIFACT_ID, _VALID_FOLDER_ARTIFACT_ID);
+
+			response.Should().NotBeNull();
+			response.Should().BeEquivalentTo(_expectedAccessStatus);
+		}
+	}
+}

--- a/source/Relativity.Testing.Framework.Api/Services/FolderService.cs
+++ b/source/Relativity.Testing.Framework.Api/Services/FolderService.cs
@@ -18,13 +18,16 @@ namespace Relativity.Testing.Framework.Api.Services
 
 		private readonly IFolderGetSubfoldersStrategy _getSubfoldersStrategy;
 
+		private readonly IFolderGetAccessStatusStrategy _getAccessStatusStrategy;
+
 		public FolderService(
 			IFolderCreateStrategy createStrategy,
 			IFolderGetByIdStrategy getByIdStrategy,
 			IFolderDeleteUnusedStrategy deleteUnusedStrategy,
 			IFolderQueryStrategy queryStrategy,
 			IFolderGetWorkspaceRootFolderStrategy getWorkspaceRootFolderStrategy,
-			IFolderGetSubfoldersStrategy getSubfoldersStrategy)
+			IFolderGetSubfoldersStrategy getSubfoldersStrategy,
+			IFolderGetAccessStatusStrategy getAccessStatusStrategy)
 		{
 			_createStrategy = createStrategy;
 			_getByIdStrategy = getByIdStrategy;
@@ -32,6 +35,7 @@ namespace Relativity.Testing.Framework.Api.Services
 			_queryStrategy = queryStrategy;
 			_getWorkspaceRootFolderStrategy = getWorkspaceRootFolderStrategy;
 			_getSubfoldersStrategy = getSubfoldersStrategy;
+			_getAccessStatusStrategy = getAccessStatusStrategy;
 		}
 
 		public Folder Create(int workspaceArtifactID, Folder folder)
@@ -51,5 +55,8 @@ namespace Relativity.Testing.Framework.Api.Services
 
 		public List<Folder> GetSubfolders(int workspaceArtifactID, int parentFolderArtifactID)
 			=> _getSubfoldersStrategy.Get(workspaceArtifactID, parentFolderArtifactID);
+
+		public FolderAccessStatus GetAccessStatus(int workspaceArtifactID, int folderArtifactID)
+			=> _getAccessStatusStrategy.Get(workspaceArtifactID, folderArtifactID);
 	}
 }

--- a/source/Relativity.Testing.Framework.Api/Services/IFolderService.cs
+++ b/source/Relativity.Testing.Framework.Api/Services/IFolderService.cs
@@ -136,5 +136,20 @@ namespace Relativity.Testing.Framework.Api.Services
 		/// </code>
 		/// </example>
 		List<Folder> GetSubfolders(int workspaceArtifactID, int parentFolderArtifactID);
+
+		/// <summary>
+		/// Gets information about the user‘s ability to access the folder.
+		/// </summary>
+		/// <param name="workspaceArtifactID">The ArtifactID of the workspace.</param>
+		/// <param name="folderArtifactID">The ArtifactID of the Folder.</param>
+		/// <returns>The [FolderAccessStatus](https://relativitydev.github.io/relativity.testing.framework/api/Relativity.Testing.Framework.Models.FolderAccessStatus.html).</returns>
+		/// <example>
+		/// <code>
+		/// int workspaceArtifactId = 1015427;
+		/// int existingFolderArtifactID = 1015657;
+		/// FolderAccessStatus folderAccessStatus = _folderService.GetAccessStatus(workspaceArtifactId, existingFolderArtifactID);
+		/// </code>
+		/// </example>
+		FolderAccessStatus GetAccessStatus(int workspaceArtifactID, int folderArtifactID);
 	}
 }

--- a/source/Relativity.Testing.Framework.Api/Strategies/Folder/DTO/FolderAccessStatusDto.cs
+++ b/source/Relativity.Testing.Framework.Api/Strategies/Folder/DTO/FolderAccessStatusDto.cs
@@ -1,0 +1,9 @@
+﻿namespace Relativity.Testing.Framework.Api.Strategies
+{
+	internal class FolderAccessStatusDto
+	{
+		public bool Exists { get; set; }
+
+		public bool CanView { get; set; }
+	}
+}

--- a/source/Relativity.Testing.Framework.Api/Strategies/Folder/DTO/FolderDtoMappingExtensions.cs
+++ b/source/Relativity.Testing.Framework.Api/Strategies/Folder/DTO/FolderDtoMappingExtensions.cs
@@ -31,5 +31,14 @@ namespace Relativity.Testing.Framework.Api.Strategies
 				Secure = dto.Secure
 			};
 		}
+
+		internal static FolderAccessStatus DoMappingToFolderAccessStatus(this FolderAccessStatusDto dto)
+		{
+			return new FolderAccessStatus
+			{
+				CanView = dto.CanView,
+				Exists = dto.Exists
+			};
+		}
 	}
 }

--- a/source/Relativity.Testing.Framework.Api/Strategies/Folder/FolderGetAccessStatusStrategy.cs
+++ b/source/Relativity.Testing.Framework.Api/Strategies/Folder/FolderGetAccessStatusStrategy.cs
@@ -1,0 +1,41 @@
+﻿using Relativity.Testing.Framework.Api.Services;
+using Relativity.Testing.Framework.Api.Validators;
+using Relativity.Testing.Framework.Models;
+
+namespace Relativity.Testing.Framework.Api.Strategies
+{
+	internal class FolderGetAccessStatusStrategy : IFolderGetAccessStatusStrategy
+	{
+		private readonly IRestService _restService;
+
+		private readonly IWorkspaceIdValidator _workspaceArtifactIdValidator;
+
+		private readonly IArtifactIdValidator _artifactIdValidator;
+
+		public FolderGetAccessStatusStrategy(
+			IRestService restService,
+			IWorkspaceIdValidator workspaceArtifactIdValidator,
+			IArtifactIdValidator artifactIdValidator)
+		{
+			_restService = restService;
+			_workspaceArtifactIdValidator = workspaceArtifactIdValidator;
+			_artifactIdValidator = artifactIdValidator;
+		}
+
+		public FolderAccessStatus Get(int workspaceArtifactID, int folderArtifactID)
+		{
+			_workspaceArtifactIdValidator.Validate(workspaceArtifactID);
+			_artifactIdValidator.Validate(folderArtifactID, "Folder");
+
+			var dto = new
+			{
+				artifactID = folderArtifactID,
+				workspaceArtifactID
+			};
+
+			FolderAccessStatusDto result = _restService.Post<FolderAccessStatusDto>("Relativity.Services.Folder.IFolderModule/Folder%20Manager/GetAccessStatusAsync", dto);
+
+			return result.DoMappingToFolderAccessStatus();
+		}
+	}
+}

--- a/source/Relativity.Testing.Framework.Api/Strategies/Folder/IFolderGetAccessStatusStrategy.cs
+++ b/source/Relativity.Testing.Framework.Api/Strategies/Folder/IFolderGetAccessStatusStrategy.cs
@@ -1,0 +1,9 @@
+﻿using Relativity.Testing.Framework.Models;
+
+namespace Relativity.Testing.Framework.Api.Strategies
+{
+	internal interface IFolderGetAccessStatusStrategy
+	{
+		FolderAccessStatus Get(int workspaceArtifactID, int folderArtifactID);
+	}
+}


### PR DESCRIPTION
Complete the following tasks before merging in your PR:
- [ ] If this is a user facing change, update [version.txt](https://github.com/relativitydev/relativity.testing.framework.api/blob/master/version.txt) and [CHANGELOG.md](https://github.com/relativitydev/relativity.testing.framework.api/blob/master/CHANGELOG.md)